### PR TITLE
Adding `SCIPchgvarobj` native support.

### DIFF
--- a/examples/Linear.java
+++ b/examples/Linear.java
@@ -17,6 +17,10 @@ public class Linear
       Variable x = scip.createVar("x", 2.0, 3.0, 1.0, SCIP_Vartype.SCIP_VARTYPE_CONTINUOUS);
       Variable y = scip.createVar("y", 0.0, scip.infinity(), -3.0, SCIP_Vartype.SCIP_VARTYPE_INTEGER);
 
+      // alternatively, you can add obj later
+      //Variable y = scip.createVar("y", 0.0, scip.infinity(), -3.0, SCIP_Vartype.SCIP_VARTYPE_INTEGER);
+      //scip.changeVarObj(y, -3.0);
+
       // create a linear constraint
       Variable[] vars = {x, y};
       double[] vals = {1.0, 2.0};

--- a/java/jscip/SCIPJNI.java
+++ b/java/jscip/SCIPJNI.java
@@ -222,6 +222,10 @@ public class SCIPJNI {
     return SCIPJNIJNI.SCIPgetGap(SWIGTYPE_p_SCIP.getCPtr(scip));
   }
 
+  public static SCIP_Retcode SCIPchgVarObj(SWIGTYPE_p_SCIP scip, SWIGTYPE_p_SCIP_VAR var, double obj) {
+    return SCIP_Retcode.swigToEnum(SCIPJNIJNI.SCIPchgVarObj(SWIGTYPE_p_SCIP.getCPtr(scip), SWIGTYPE_p_SCIP_VAR.getCPtr(var), obj));
+  }
+
   public static SCIP_Retcode SCIPchgVarBranchPriority(SWIGTYPE_p_SCIP scip, SWIGTYPE_p_SCIP_VAR var, int branchpriority) {
     return SCIP_Retcode.swigToEnum(SCIPJNIJNI.SCIPchgVarBranchPriority(SWIGTYPE_p_SCIP.getCPtr(scip), SWIGTYPE_p_SCIP_VAR.getCPtr(var), branchpriority));
   }

--- a/java/jscip/SCIPJNIJNI.java
+++ b/java/jscip/SCIPJNIJNI.java
@@ -95,6 +95,7 @@ public class SCIPJNIJNI {
   public final static native int SCIPsetObjsense(long jarg1, int jarg2);
   public final static native int SCIPgetObjsense(long jarg1);
   public final static native double SCIPgetGap(long jarg1);
+  public final static native int SCIPchgVarObj(long jarg1, long jarg2, double jarg3);
   public final static native int SCIPchgVarBranchPriority(long jarg1, long jarg2, int jarg3);
   public final static native int SCIPcreateSol(long jarg1, long jarg2, long jarg3);
   public final static native int SCIPsetSolVal(long jarg1, long jarg2, long jarg3, double jarg4);

--- a/java/jscip/Scip.java
+++ b/java/jscip/Scip.java
@@ -147,6 +147,13 @@ public class Scip
       return var;
    }
 
+   /** wraps SCIPchgVarObj() */
+   public void changeVarObj(Variable var, double obj)
+   {
+      assert(var.getPtr() != null);
+      CHECK_RETCODE( SCIPJNI.SCIPchgVarObj(_scipptr, var.getPtr(), obj));
+   }
+
    /** wraps SCIPreleaseVar() */
    public void releaseVar(Variable var)
    {

--- a/src/scipjni.i
+++ b/src/scipjni.i
@@ -183,6 +183,7 @@ SCIP_RETCODE   SCIPsetEmphasis(SCIP* scip, SCIP_PARAMEMPHASIS paramemphasis, SCI
 SCIP_RETCODE   SCIPsetObjsense(SCIP* scip, SCIP_OBJSENSE objsense);
 SCIP_OBJSENSE  SCIPgetObjsense(SCIP* scip);
 SCIP_Real      SCIPgetGap(SCIP* scip);
+SCIP_RETCODE   SCIPchgVarObj(SCIP* scip, SCIP_VAR* var, SCIP_Real obj);
 
 /* from scip_var.h */
 SCIP_RETCODE   SCIPchgVarBranchPriority(SCIP* scip, SCIP_VAR* var, int branchpriority);

--- a/src/scipjni_wrap.c
+++ b/src/scipjni_wrap.c
@@ -1611,6 +1611,24 @@ SWIGEXPORT jdouble JNICALL Java_jscip_SCIPJNIJNI_SCIPgetGap(JNIEnv *jenv, jclass
 }
 
 
+SWIGEXPORT jint JNICALL Java_jscip_SCIPJNIJNI_SCIPchgVarObj(JNIEnv *jenv, jclass jcls, jlong jarg1, jlong jarg2, jdouble jarg3) {
+  jint jresult = 0 ;
+  SCIP *arg1 = (SCIP *) 0 ;
+  SCIP_VAR *arg2 = (SCIP_VAR *) 0 ;
+  double arg3 ;
+  SCIP_RETCODE result;
+  
+  (void)jenv;
+  (void)jcls;
+  arg1 = *(SCIP **)&jarg1; 
+  arg2 = *(SCIP_VAR **)&jarg2; 
+  arg3 = (double)jarg3; 
+  result = (SCIP_RETCODE)SCIPchgVarObj(arg1,arg2,arg3);
+  jresult = (jint)result; 
+  return jresult;
+}
+
+
 SWIGEXPORT jint JNICALL Java_jscip_SCIPJNIJNI_SCIPchgVarBranchPriority(JNIEnv *jenv, jclass jcls, jlong jarg1, jlong jarg2, jint jarg3) {
   jint jresult = 0 ;
   SCIP *arg1 = (SCIP *) 0 ;


### PR DESCRIPTION
This is quite useful in real scenarios, that decouple the definition of the objective function and the variables. This pull request adding interface `scip.changeVarObj` to support that, please check the usage below.

Usage:
```
Variable y = scip.createVar("y", 0.0, scip.infinity(), 0.0, SCIP_Vartype.SCIP_VARTYPE_INTEGER);
scip.changeVarObj(y, -3.0);

// Equivalent to below line
Variable y = scip.createVar("y", 0.0, scip.infinity(), -3.0, SCIP_Vartype.SCIP_VARTYPE_INTEGER);
```