### PR TITLE
add support for solveConcurrent

### DIFF
--- a/java/jscip/SCIPJNI.java
+++ b/java/jscip/SCIPJNI.java
@@ -111,6 +111,10 @@ public class SCIPJNI {
     return SCIP_Retcode.swigToEnum(SCIPJNIJNI.SCIPsolve(SWIGTYPE_p_SCIP.getCPtr(scip)));
   }
 
+  public static SCIP_Retcode SCIPsolveConcurrent(SWIGTYPE_p_SCIP scip) {
+    return SCIP_Retcode.swigToEnum(SCIPJNIJNI.SCIPsolveConcurrent(SWIGTYPE_p_SCIP.getCPtr(scip)));
+  }
+
   public static SCIP_Retcode SCIPaddVar(SWIGTYPE_p_SCIP scip, SWIGTYPE_p_SCIP_VAR var) {
     return SCIP_Retcode.swigToEnum(SCIPJNIJNI.SCIPaddVar(SWIGTYPE_p_SCIP.getCPtr(scip), SWIGTYPE_p_SCIP_VAR.getCPtr(var)));
   }

--- a/java/jscip/SCIPJNIJNI.java
+++ b/java/jscip/SCIPJNIJNI.java
@@ -68,6 +68,7 @@ public class SCIPJNIJNI {
   public final static native int SCIPcreateProbBasic(long jarg1, String jarg2);
   public final static native int SCIPincludeDefaultPlugins(long jarg1);
   public final static native int SCIPsolve(long jarg1);
+  public final static native int SCIPsolveConcurrent(long jarg1);
   public final static native int SCIPaddVar(long jarg1, long jarg2);
   public final static native long SCIPgetVars(long jarg1);
   public final static native int SCIPaddCons(long jarg1, long jarg2);

--- a/java/jscip/Scip.java
+++ b/java/jscip/Scip.java
@@ -39,6 +39,12 @@ public class Scip
       CHECK_RETCODE( SCIPJNI.SCIPsolve(_scipptr) );
    }
 
+   /** wraps SCIPsolveConcurrent() */
+   public void solveConcurrent()
+   {
+      CHECK_RETCODE( SCIPJNI.SCIPsolveConcurrent(_scipptr) );
+   }
+
    /** wraps SCIPsetMessagehdlrQuiet() */
    public void hideOutput(boolean quite)
    {

--- a/src/scipjni.i
+++ b/src/scipjni.i
@@ -155,6 +155,7 @@ SCIP_RETCODE   SCIPreadParams(SCIP* scip, const char* filename);
 SCIP_RETCODE   SCIPcreateProbBasic(SCIP* scip, const char* probname);
 SCIP_RETCODE   SCIPincludeDefaultPlugins(SCIP* scip);
 SCIP_RETCODE   SCIPsolve(SCIP* scip);
+SCIP_RETCODE   SCIPsolveConcurrent(SCIP* scip);
 SCIP_RETCODE   SCIPaddVar(SCIP* scip, SCIP_VAR* var);
 int            SCIPgetNVars(SCIP* scip);
 SCIP_VAR**     SCIPgetVars(SCIP* scip);

--- a/src/scipjni_wrap.c
+++ b/src/scipjni_wrap.c
@@ -1120,6 +1120,20 @@ SWIGEXPORT jint JNICALL Java_jscip_SCIPJNIJNI_SCIPsolve(JNIEnv *jenv, jclass jcl
 }
 
 
+SWIGEXPORT jint JNICALL Java_jscip_SCIPJNIJNI_SCIPsolveConcurrent(JNIEnv *jenv, jclass jcls, jlong jarg1) {
+  jint jresult = 0 ;
+  SCIP *arg1 = (SCIP *) 0 ;
+  SCIP_RETCODE result;
+  
+  (void)jenv;
+  (void)jcls;
+  arg1 = *(SCIP **)&jarg1; 
+  result = (SCIP_RETCODE)SCIPsolveConcurrent(arg1);
+  jresult = (jint)result; 
+  return jresult;
+}
+
+
 SWIGEXPORT jint JNICALL Java_jscip_SCIPJNIJNI_SCIPaddVar(JNIEnv *jenv, jclass jcls, jlong jarg1, jlong jarg2) {
   jint jresult = 0 ;
   SCIP *arg1 = (SCIP *) 0 ;


### PR DESCRIPTION
src/scipjni.i: Declare SCIPsolveConcurrent from scip.h to be wrapped.

java/jscip/Scip.java: Wrap SCIPsolveConcurrent as Scip.solveConcurrent.

Regenerate src/scipjni_wrap.c and the generated java/jscip/*.java files
with SWIG 4.0.2.

Of course, this will only work as expected if SCIP is actually built
with concurrent solving support enabled. Otherwise, it will throw an
exception.