### PR TITLE
do not use non-portable mv command after running SWIG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,7 @@ set(JAVA_SOURCES
 find_package (SWIG)
 if (SWIG_FOUND)
   add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/src/scipjni_wrap.c ${SWIG_JAVA_SOURCES}
-    COMMAND ${SWIG_EXECUTABLE} -package jscip -java ${PROJECT_SOURCE_DIR}/src/scipjni.i
-    COMMAND mv ${PROJECT_SOURCE_DIR}/src/*.java ${PROJECT_SOURCE_DIR}/java/jscip/
+    COMMAND ${SWIG_EXECUTABLE} -package jscip -java -outdir ${PROJECT_SOURCE_DIR}/java/jscip/ ${PROJECT_SOURCE_DIR}/src/scipjni.i
     DEPENDS ${PROJECT_SOURCE_DIR}/src/scipjni.i)
 endif()
 


### PR DESCRIPTION
CMakeLists.txt: Change the custom command for the SWIG_FOUND case to
generate the SWIG files directly in the correct directory instead of
using mv. This fixes the build on Windows/MSVC and works fine under
GNU/Linux as well.