### PR TITLE
adds Scip::createPartialSol.

### DIFF
--- a/java/jscip/SCIPJNI.java
+++ b/java/jscip/SCIPJNI.java
@@ -246,6 +246,10 @@ public class SCIPJNI {
     return SCIP_Retcode.swigToEnum(SCIPJNIJNI.SCIPcreateSol(SWIGTYPE_p_SCIP.getCPtr(scip), SWIGTYPE_p_p_SCIP_SOL.getCPtr(sol), SWIGTYPE_p_SCIP_HEUR.getCPtr(heur)));
   }
 
+    public static SCIP_Retcode SCIPcreatePartialSol(SWIGTYPE_p_SCIP scip, SWIGTYPE_p_p_SCIP_SOL sol, SWIGTYPE_p_SCIP_HEUR heur) {
+    return SCIP_Retcode.swigToEnum(SCIPJNIJNI.SCIPcreatePartialSol(SWIGTYPE_p_SCIP.getCPtr(scip), SWIGTYPE_p_p_SCIP_SOL.getCPtr(sol), SWIGTYPE_p_SCIP_HEUR.getCPtr(heur)));
+  }
+
   public static SCIP_Retcode SCIPsetSolVal(SWIGTYPE_p_SCIP scip, SWIGTYPE_p_SCIP_SOL sol, SWIGTYPE_p_SCIP_VAR var, double val) {
     return SCIP_Retcode.swigToEnum(SCIPJNIJNI.SCIPsetSolVal(SWIGTYPE_p_SCIP.getCPtr(scip), SWIGTYPE_p_SCIP_SOL.getCPtr(sol), SWIGTYPE_p_SCIP_VAR.getCPtr(var), val));
   }

--- a/java/jscip/SCIPJNIJNI.java
+++ b/java/jscip/SCIPJNIJNI.java
@@ -123,6 +123,7 @@ public class SCIPJNIJNI {
   public final static native int SCIPchgVarObj(long jarg1, long jarg2, double jarg3);
   public final static native int SCIPchgVarBranchPriority(long jarg1, long jarg2, int jarg3);
   public final static native int SCIPcreateSol(long jarg1, long jarg2, long jarg3);
+  public final static native int SCIPcreatePartialSol(long jarg1, long jarg2, long jarg3);
   public final static native int SCIPsetSolVal(long jarg1, long jarg2, long jarg3, double jarg4);
   public final static native int SCIPsetSolVals(long jarg1, long jarg2, int jarg3, long jarg4, long jarg5);
   public final static native int SCIPaddSolFree(long jarg1, long jarg2, long jarg3);

--- a/java/jscip/Scip.java
+++ b/java/jscip/Scip.java
@@ -440,6 +440,16 @@ public class Scip
       return sol;
    }
 
+   /** wraps SCIPcreatePartialSol() */
+   public Solution createPartialSol()
+   {
+      SWIGTYPE_p_p_SCIP_SOL solptr = SCIPJNI.new_SCIP_SOL_array(1);
+      CHECK_RETCODE( SCIPJNI.SCIPcreatePartialSol(_scipptr, solptr, null) );
+      Solution sol = new Solution(SCIPJNI.SCIP_SOL_array_getitem(solptr, 0));
+      SCIPJNI.delete_SCIP_SOL_array(solptr);
+      return sol;
+   }
+
    /** wraps SCIPsetSolVal() */
    public void setSolVal(Solution sol, Variable var, double val)
    {

--- a/src/scipjni.i
+++ b/src/scipjni.i
@@ -305,6 +305,7 @@ SCIP_RETCODE   SCIPchgVarBranchPriority(SCIP* scip, SCIP_VAR* var, int branchpri
 
 /* from scip_sol.h */
 SCIP_RETCODE   SCIPcreateSol(SCIP* scip, SCIP_SOL** sol, SCIP_HEUR* heur);
+SCIP_RETCODE   SCIPcreatePartialSol(SCIP* scip, SCIP_SOL** sol, SCIP_HEUR* heur);
 SCIP_RETCODE   SCIPsetSolVal(SCIP* scip, SCIP_SOL* sol, SCIP_VAR* var, SCIP_Real val);
 SCIP_RETCODE   SCIPsetSolVals(SCIP* scip, SCIP_SOL* sol, int nvars, SCIP_VAR** vars, SCIP_Real* val);
 SCIP_RETCODE   SCIPaddSolFree(SCIP* scip, SCIP_SOL** sol, SCIP_Bool *stored);

--- a/src/scipjni_wrap.cxx
+++ b/src/scipjni_wrap.cxx
@@ -2814,6 +2814,22 @@ SWIGEXPORT jint JNICALL Java_jscip_SCIPJNIJNI_SCIPcreateSol(JNIEnv *jenv, jclass
   return jresult;
 }
 
+SWIGEXPORT jint JNICALL Java_jscip_SCIPJNIJNI_SCIPcreatePartialSol(JNIEnv *jenv, jclass jcls, jlong jarg1, jlong jarg2, jlong jarg3) {
+  jint jresult = 0 ;
+  SCIP *arg1 = (SCIP *) 0 ;
+  SCIP_SOL **arg2 = (SCIP_SOL **) 0 ;
+  SCIP_HEUR *arg3 = (SCIP_HEUR *) 0 ;
+  SCIP_RETCODE result;
+  
+  (void)jenv;
+  (void)jcls;
+  arg1 = *(SCIP **)&jarg1; 
+  arg2 = *(SCIP_SOL ***)&jarg2; 
+  arg3 = *(SCIP_HEUR **)&jarg3; 
+  result = (SCIP_RETCODE)SCIPcreatePartialSol(arg1,arg2,arg3);
+  jresult = (jint)result; 
+  return jresult;
+}
 
 SWIGEXPORT jint JNICALL Java_jscip_SCIPJNIJNI_SCIPsetSolVal(JNIEnv *jenv, jclass jcls, jlong jarg1, jlong jarg2, jlong jarg3, jdouble jarg4) {
   jint jresult = 0 ;


### PR DESCRIPTION
I'm developing a modeling DSL. You can see [There](https://github.com/fuookami/ospf-kotlin/blob/1b4e0f66b6b4035c786cfc30dc12aea41dee379f/ospf-kotlin-core-plugin-scip/src/main/fuookami/ospf/kotlin/core/backend/plugins/scip/SCIPLinearSolver.kt) in line 96. There will be some variables generated by the DSL and users don't know. So, the initial solution user could provide doesn't contains all the variable in the final model. I have tried in C interface. If i use "SCIP::createSol", the initial solution has no effect. I need to use "SCIP::createPartialSol".